### PR TITLE
[Feat/#7] CategoryScreen UI 구현

### DIFF
--- a/app/src/main/java/org/sopt/carrot/core/extension/Modifier.kt
+++ b/app/src/main/java/org/sopt/carrot/core/extension/Modifier.kt
@@ -1,0 +1,17 @@
+package org.sopt.carrot.core.extension
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier =
+    composed {
+        clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() }
+        ) {
+            onClick()
+        }
+    }

--- a/app/src/main/java/org/sopt/carrot/presentation/NavHost.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/NavHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import org.sopt.carrot.presentation.ExampleScreen1.ExampleScreen1
 import org.sopt.carrot.presentation.ExampleScreen2.ExampleScreen2
+import org.sopt.carrot.presentation.category.CategoryScreen
 
 @Composable
 fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
@@ -17,5 +18,12 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
     ) {
         composable(ScreenRoutes.EXAMPLE_SCREEN_1) { ExampleScreen1(navController) }
         composable(ScreenRoutes.EXAMPLE_SCREEN_2) { ExampleScreen2(navController) }
+
+        composable(ScreenRoutes.CATEGORY_SCREEN) {
+            CategoryScreen(
+                onBackClick = { navController.popBackStack() },
+                navigateToHome = { navController.navigate(ScreenRoutes.EXAMPLE_SCREEN_2) }
+            )
+        }
     }
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/ScreenRoute.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/ScreenRoute.kt
@@ -3,4 +3,5 @@ package org.sopt.carrot.presentation
 object ScreenRoutes {
     const val EXAMPLE_SCREEN_1 = "example_screen_1"
     const val EXAMPLE_SCREEN_2 = "example_screen_2"
+    const val CATEGORY_SCREEN = "category_screen"
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
@@ -9,9 +9,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import org.sopt.carrot.R
 import org.sopt.carrot.presentation.category.component.CategoryBottomBar
 import org.sopt.carrot.presentation.category.component.CategoryTopBar
 import org.sopt.carrot.presentation.category.component.section.CategorySelection
@@ -67,7 +69,7 @@ private fun CategoryContent(
             .padding(top = 24.dp)
     ) {
         Text(
-            text = "상세필터",
+            text = stringResource(R.string.category_filter_title),
             style = CarrotTheme.typography.title.b_25,
             modifier = Modifier.padding(start = 16.dp),
         )

--- a/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.sopt.carrot.presentation.category.component.CategoryBottomBar
 import org.sopt.carrot.presentation.category.component.CategoryTopBar
 import org.sopt.carrot.presentation.category.component.section.CategorySelection
-import org.sopt.carrot.presentation.category.component.section.FitterTabs
+import org.sopt.carrot.presentation.category.component.section.FilterTabs
 import org.sopt.carrot.ui.theme.CarrotTheme
 
 @Composable
@@ -74,7 +74,7 @@ private fun CategoryContent(
 
         Spacer(modifier = Modifier.height(13.dp))
 
-        FitterTabs()
+        FilterTabs()
 
         CategorySelection(
             categories = categories,

--- a/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/CategoryScreen.kt
@@ -1,4 +1,90 @@
 package org.sopt.carrot.presentation.category
 
-class CategoryScreen {
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.sopt.carrot.presentation.category.component.CategoryBottomBar
+import org.sopt.carrot.presentation.category.component.CategoryTopBar
+import org.sopt.carrot.presentation.category.component.section.CategorySelection
+import org.sopt.carrot.presentation.category.component.section.FitterTabs
+import org.sopt.carrot.ui.theme.CarrotTheme
+
+@Composable
+fun CategoryScreen(
+    onBackClick: () -> Unit = {},
+    navigateToHome: () -> Unit = {},
+    viewmodel: CategoryViewmodel = viewModel(),
+) {
+    val categories = viewmodel.categorySelections
+
+    Scaffold(
+        topBar = {
+            CategoryTopBar(
+                onBackClick = onBackClick
+            )
+        },
+        bottomBar = {
+            CategoryBottomBar(
+                isEnabled = viewmodel.check(),
+                onClearSelectedCategories = { viewmodel.clearSelectedCategories() },
+                onApplyCategories = {
+                    // TODO 서버 전달 추가 예정
+                    navigateToHome()
+                }
+            )
+        },
+        containerColor = CarrotTheme.colors.white,
+        content = { paddingValues ->
+            CategoryContent(
+                modifier = Modifier.padding(paddingValues),
+                categories = categories,
+                onCheckedChange = { category ->
+                    viewmodel.toggleCategoryProcess(category)
+                },
+            )
+        }
+    )
+}
+
+@Composable
+private fun CategoryContent(
+    modifier: Modifier,
+    categories: Map<String, Boolean>,
+    onCheckedChange: (String) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(top = 24.dp)
+    ) {
+        Text(
+            text = "상세필터",
+            style = CarrotTheme.typography.title.b_25,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+
+        Spacer(modifier = Modifier.height(13.dp))
+
+        FitterTabs()
+
+        CategorySelection(
+            categories = categories,
+            onCheckedChange = onCheckedChange
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryScreen() {
+    CategoryScreen()
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/category/CategoryViewmodel.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/CategoryViewmodel.kt
@@ -1,0 +1,64 @@
+package org.sopt.carrot.presentation.category
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class CategoryViewmodel : ViewModel() {
+
+    private val categories = listOf(
+        "디지털기기",
+        "가구/인테리어",
+        "유아동",
+        "여성의류",
+        "여성잡화",
+        "남성패션/잡화",
+        "생활가전",
+        "생활/주방",
+        "스포츠/레저",
+        "취미/게임/음반",
+        "뷰티/미용",
+        "식물",
+        "가공식품",
+        "건강기능식품",
+        "반려동물용품",
+        "티켓/교환권",
+        "도서",
+        "유아도서",
+        "기타 중고물품",
+        "삽니다"
+    )
+
+    var categorySelections by mutableStateOf(categories.associateWith { false })
+        private set
+
+    var selectedCategories by mutableStateOf<List<String>>(emptyList())
+        private set
+
+    fun check(): Boolean = (selectedCategories.isNotEmpty())
+
+    fun toggleCategoryProcess(category: String) {
+        toggleCategory(category)
+        addSelectedCategories(category)
+    }
+
+    private fun toggleCategory(category: String) {
+        categorySelections = categorySelections.toMutableMap().apply {
+            this[category] = !(this[category] ?: false)
+        }
+    }
+
+    private fun addSelectedCategories(category: String) {
+        selectedCategories = when (categorySelections[category] == true) {
+            true -> selectedCategories.plus(category)
+            false -> selectedCategories.minus(category)
+        }
+    }
+
+    fun clearSelectedCategories() {
+        categorySelections = categories.associateWith { false }
+        selectedCategories = emptyList()
+    }
+
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.sopt.carrot.R
 import org.sopt.carrot.core.extension.noRippleClickable
 import org.sopt.carrot.ui.theme.CarrotTheme
 
@@ -49,7 +51,7 @@ fun CategoryBottomBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "초기화",
+                text = stringResource(R.string.category_clear_button),
                 color = CarrotTheme.colors.gray8,
                 style = CarrotTheme.typography.body.b_18
             )
@@ -74,7 +76,7 @@ fun CategoryBottomBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "적용하기",
+                text = stringResource(R.string.category_apply_button),
                 color = CarrotTheme.colors.white,
                 style = CarrotTheme.typography.body.b_18
             )

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
@@ -42,10 +42,8 @@ fun CategoryBottomBar(
                     shape = RoundedCornerShape(6.dp)
                 )
                 .padding(
-                    top = 18.dp,
-                    bottom = 19.dp,
-                    start = 36.dp,
-                    end = 36.dp
+                    vertical = 18.dp,
+                    horizontal = 36.dp,
                 ),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryBottomBar.kt
@@ -1,0 +1,109 @@
+package org.sopt.carrot.presentation.category.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.carrot.core.extension.noRippleClickable
+import org.sopt.carrot.ui.theme.CarrotTheme
+
+@Composable
+fun CategoryBottomBar(
+    isEnabled: Boolean,
+    onClearSelectedCategories: () -> Unit,
+    onApplyCategories: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                top = 28.dp,
+                bottom = 60.dp,
+                start = 16.dp,
+                end = 16.dp
+            ),
+        horizontalArrangement = Arrangement.spacedBy(19.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier = Modifier
+                .noRippleClickable { onClearSelectedCategories() }
+                .background(
+                    color = CarrotTheme.colors.gray2,
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(
+                    top = 18.dp,
+                    bottom = 19.dp,
+                    start = 36.dp,
+                    end = 36.dp
+                ),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "초기화",
+                color = CarrotTheme.colors.gray8,
+                style = CarrotTheme.typography.body.b_18
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .noRippleClickable { onApplyCategories() }
+                .fillMaxWidth()
+                .background(
+                    color = when (isEnabled) {
+                        true -> CarrotTheme.colors.orange1
+                        false -> CarrotTheme.colors.gray5
+                    },
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(
+                    top = 18.dp,
+                    bottom = 19.dp
+                ),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "적용하기",
+                color = CarrotTheme.colors.white,
+                style = CarrotTheme.typography.body.b_18
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryBottomBar() {
+    Column {
+        CategoryBottomBar(
+            isEnabled = false,
+            onClearSelectedCategories = {},
+            onApplyCategories = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryBottomBar2() {
+    Column {
+        CategoryBottomBar(
+            isEnabled = true,
+            onClearSelectedCategories = {},
+            onApplyCategories = {}
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryTopBar.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/CategoryTopBar.kt
@@ -1,0 +1,42 @@
+package org.sopt.carrot.presentation.category.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.carrot.R
+import org.sopt.carrot.core.extension.noRippleClickable
+import org.sopt.carrot.ui.theme.CarrotTheme
+
+@Composable
+fun CategoryTopBar(
+    onBackClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .padding(
+                start = 16.dp,
+                top = 55.dp
+            )
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_direction_left_black_28),
+            contentDescription = "",
+            modifier = Modifier.noRippleClickable { onBackClick() },
+            tint = CarrotTheme.colors.black
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewCategoryTopBar() {
+    CategoryTopBar(
+        onBackClick = {}
+    )
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/item/CategoryCheckBox.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/item/CategoryCheckBox.kt
@@ -1,0 +1,63 @@
+package org.sopt.carrot.presentation.category.component.item
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.carrot.R
+import org.sopt.carrot.core.extension.noRippleClickable
+import org.sopt.carrot.ui.theme.CarrotTheme
+
+@Composable
+fun CategoryCheckBox(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(13.dp, Alignment.Start),
+        modifier = Modifier
+            .height(22.dp)
+            .noRippleClickable { onCheckedChange() }
+    ) {
+        Icon(
+            imageVector = when (checked) {
+                true -> ImageVector.vectorResource(R.drawable.ic_checkbox_selected_22)
+                false -> ImageVector.vectorResource(R.drawable.ic_checkbox_normal_22)
+            },
+            contentDescription = "",
+            tint = Color.Unspecified
+        )
+        Text(
+            text = title,
+            style = CarrotTheme.typography.body.sb_17_08,
+            modifier = Modifier.fillMaxHeight()
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewCategoryCheckBox() {
+    var isChecked by remember { mutableStateOf(false) }
+
+    CategoryCheckBox(
+        title = "디지털기기",
+        checked = isChecked,
+        onCheckedChange = { isChecked = !isChecked }
+    )
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/section/CategorySelection.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/section/CategorySelection.kt
@@ -1,0 +1,57 @@
+package org.sopt.carrot.presentation.category.component.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.carrot.presentation.category.component.item.CategoryCheckBox
+
+@Composable
+fun CategorySelection(
+    categories: Map<String, Boolean>,
+    onCheckedChange: (String) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(
+            items = categories.toList(),
+            key = { item: Pair<String, Boolean> -> item.first }
+        ) { (category, checked) ->
+            Column(
+                verticalArrangement = Arrangement.spacedBy(26.dp),
+                modifier = Modifier
+                    .padding(
+                        top = 26.dp,
+                        start = 16.dp
+                    )
+            ) {
+                CategoryCheckBox(
+                    title = category,
+                    checked = checked,
+                    onCheckedChange = { onCheckedChange(category) }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewCategorySelection() {
+    val categories = mapOf(
+        "디지털기기" to false,
+        "옷" to true
+    )
+
+    CategorySelection(
+        categories = categories,
+        onCheckedChange = {}
+    )
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FilterTabs.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FilterTabs.kt
@@ -19,7 +19,7 @@ import okhttp3.internal.toImmutableList
 import org.sopt.carrot.ui.theme.CarrotTheme
 
 @Composable
-fun FitterTabs() {
+fun FilterTabs() {
     val selectedIndex by remember { mutableIntStateOf(2) }
     val tabs = listOf("동네거리", "가격", "카테고리", "정확도순").toImmutableList()
 
@@ -65,6 +65,6 @@ fun FitterTabs() {
 
 @Preview
 @Composable
-private fun PreviewFitterTabSection() {
-    FitterTabs()
+private fun PreviewFilterTabSection() {
+    FilterTabs()
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FilterTabs.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FilterTabs.kt
@@ -1,7 +1,7 @@
 package org.sopt.carrot.presentation.category.component.section
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -47,7 +47,7 @@ fun FilterTabs() {
                     selected = selectedIndex == index,
                     onClick = {},
                     modifier = Modifier
-                        .width(80.dp)
+                        .wrapContentWidth()
                         .padding(horizontal = 10.dp),
                     selectedContentColor = CarrotTheme.colors.gray8,
                     unselectedContentColor = CarrotTheme.colors.gray6

--- a/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FitterTabs.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/category/component/section/FitterTabs.kt
@@ -1,0 +1,70 @@
+package org.sopt.carrot.presentation.category.component.section
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import okhttp3.internal.toImmutableList
+import org.sopt.carrot.ui.theme.CarrotTheme
+
+@Composable
+fun FitterTabs() {
+    val selectedIndex by remember { mutableIntStateOf(2) }
+    val tabs = listOf("동네거리", "가격", "카테고리", "정확도순").toImmutableList()
+
+    TabRow(
+        selectedTabIndex = selectedIndex,
+        containerColor = CarrotTheme.colors.white,
+        indicator = { tabPositions ->
+            TabRowDefaults.SecondaryIndicator(
+                modifier = Modifier
+                    .tabIndicatorOffset(tabPositions[selectedIndex])
+                    .padding(horizontal = 10.dp),
+                height = 2.dp,
+                color = CarrotTheme.colors.gray8,
+            )
+        },
+        divider = {
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = CarrotTheme.colors.gray2
+            )
+        },
+        tabs = {
+            tabs.forEachIndexed { index, tab ->
+                Tab(
+                    selected = selectedIndex == index,
+                    onClick = {},
+                    modifier = Modifier
+                        .width(80.dp)
+                        .padding(horizontal = 10.dp),
+                    selectedContentColor = CarrotTheme.colors.gray8,
+                    unselectedContentColor = CarrotTheme.colors.gray6
+                ) {
+                    Text(
+                        text = tab,
+                        style = CarrotTheme.typography.body.b_17,
+                        modifier = Modifier.padding(vertical = 13.dp),
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewFitterTabSection() {
+    FitterTabs()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">CARROT</string>
+
+    <!--category screen-->
+    <string name="category_filter_title">상세필터</string>
+    <string name="category_clear_button">초기화</string>
+    <string name="category_apply_button">적용하기</string>
+
 </resources>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- [x] 리뷰는 (아직 미정)에 진행됩니다.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #7 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 카테고리 선택 checkBox 기능 구현
- 선택 카테고리 일괄 초기화 기능 구현
- 선택 카테고리 적용 기능 UI만 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/52768962-afa1-4fd2-8a9e-3160fb312f2f

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 이번 작업에서는 UI 구현 위주로 진행했습니다!!
- 컴포넌트 구조는 item과 section으로 나누어 진행했습니다.
  -  item -> section에서 사용
  - section -> screen을 구성하는 하나의 부분
- viewmodel은 우선 임시로 작성했습니다! 추후 서버와 연결 작업하며 보강해보겠습니다! 🥕
- 추가로 Ripple효과 제거 확장함수로 구현했으니 마구마구 사용하세요~
  - 기본적으로 onclick을 제공하는 컴포넌트에서는 사용이 불가능하더라고요,,( 불편하시면 추후 공부 후 리펙해보겠습니다.!)