### PR TITLE
[Hotfix/#21] BaseResponse 및 서버통신 로직 수정

### DIFF
--- a/app/src/main/java/org/sopt/carrot/data/ApiFactory.kt
+++ b/app/src/main/java/org/sopt/carrot/data/ApiFactory.kt
@@ -32,5 +32,5 @@ object ApiFactory {
 }
 
 object ServicePool {
-    val dummyService = ApiFactory.create<DummyService>()
+    val dummyService by lazy { ApiFactory.create<DummyService>() }
 }

--- a/app/src/main/java/org/sopt/carrot/data/model/response/BaseResponse.kt
+++ b/app/src/main/java/org/sopt/carrot/data/model/response/BaseResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class BaseResponse<T>(
     val status: Int,
-    val data: T? = null,
-    val message: String,
+    val result: T? = null,
+    val message: String? = null,
 )

--- a/app/src/main/java/org/sopt/carrot/presentation/util/UiState.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/util/UiState.kt
@@ -1,0 +1,11 @@
+package org.sopt.carrot.presentation.util
+
+sealed class UiState<out T> {
+    object Loading : UiState<Nothing>()
+
+    object Empty : UiState<Nothing>()
+
+    data class Success<T>(val data: T) : UiState<T>()
+
+    data class Error(val message: String?) : UiState<Nothing>()
+}


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #21 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- BaseResponse 형식 때문에 서버로부터 값을 못받아와서 수정했습니다.
- UiState 추가했습니다
- ApiFactory ServicePool에서 Service 선언 방식 변경했습니다.

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
없습니다

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
캘롯캐롯..캐롯캐롯...캘롯코롯ㅋ롯...ㅠㅠ (다 이해했지?)