### PR TITLE
[Feat/#27] 판매자 유저 정보 서버통신 구현

### DIFF
--- a/app/src/main/java/org/sopt/carrot/core/common/ViewModelFactory.kt
+++ b/app/src/main/java/org/sopt/carrot/core/common/ViewModelFactory.kt
@@ -13,7 +13,7 @@ import org.sopt.carrot.data.repositoryimpl.UserRepositoryImpl
 import org.sopt.carrot.presentation.ExampleScreen1.ExampleScreen1ViewModel
 import org.sopt.carrot.presentation.productDetailScreen.ProductDetailViewModel
 import org.sopt.carrot.presentation.category.CategoryViewmodel
-import org.sopt.carrot.presentation.sellerProfile.SellerProfileViewmodel
+import org.sopt.carrot.presentation.sellerProfile.SellerProfileViewModel
 import org.sopt.carrot.presentation.titleSearchScreen.SearchViewModel
 
 
@@ -46,8 +46,8 @@ class ViewModelFactory : ViewModelProvider.Factory {
                 ) as T
             }
 
-            SellerProfileViewmodel::class.java -> {
-                SellerProfileViewmodel(
+            SellerProfileViewModel::class.java -> {
+                SellerProfileViewModel(
                     UserRepositoryImpl(ServicePool.userService)
                 ) as T
             }

--- a/app/src/main/java/org/sopt/carrot/core/common/ViewModelFactory.kt
+++ b/app/src/main/java/org/sopt/carrot/core/common/ViewModelFactory.kt
@@ -13,6 +13,7 @@ import org.sopt.carrot.data.repositoryimpl.UserRepositoryImpl
 import org.sopt.carrot.presentation.ExampleScreen1.ExampleScreen1ViewModel
 import org.sopt.carrot.presentation.productDetailScreen.ProductDetailViewModel
 import org.sopt.carrot.presentation.category.CategoryViewmodel
+import org.sopt.carrot.presentation.sellerProfile.SellerProfileViewmodel
 import org.sopt.carrot.presentation.titleSearchScreen.SearchViewModel
 
 
@@ -41,6 +42,12 @@ class ViewModelFactory : ViewModelProvider.Factory {
             ProductDetailViewModel::class.java -> {
                 ProductDetailViewModel(
                     ProductDetailRepositoryImpl(ServicePool.productService),
+                    UserRepositoryImpl(ServicePool.userService)
+                ) as T
+            }
+
+            SellerProfileViewmodel::class.java -> {
+                SellerProfileViewmodel(
                     UserRepositoryImpl(ServicePool.userService)
                 ) as T
             }

--- a/app/src/main/java/org/sopt/carrot/data/mapper/UserMapper.kt
+++ b/app/src/main/java/org/sopt/carrot/data/mapper/UserMapper.kt
@@ -3,9 +3,10 @@ package org.sopt.carrot.data.mapper
 import org.sopt.carrot.data.model.response.ResponseUserInfoDto
 import org.sopt.carrot.domain.model.UserDetail
 
-fun ResponseUserInfoDto.toUserDetail() = UserDetail(
-    userId = userId,
-    nickname = nickname,
-    profileImage = profileImage,
-    address = address
-)
+fun ResponseUserInfoDto.toUserDetail() =
+    UserDetail(
+        userId = this.userId,
+        nickname = this.nickname,
+        profileImage = this.profileImage,
+        address = this.address
+    )

--- a/app/src/main/java/org/sopt/carrot/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/carrot/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,15 +1,37 @@
 package org.sopt.carrot.data.repositoryimpl
 
-
 import org.sopt.carrot.data.mapper.toUserDetail
+import org.sopt.carrot.data.model.response.isClientError
+import org.sopt.carrot.data.model.response.isServerError
+import org.sopt.carrot.data.model.response.isSuccess
 import org.sopt.carrot.data.service.UserService
+import org.sopt.carrot.domain.model.UserDetail
 import org.sopt.carrot.domain.repository.UserRepository
 
 class UserRepositoryImpl(
     private val userService: UserService
 ) : UserRepository {
-    override suspend fun getUserInfo(userId: Long) = runCatching {
-        userService.getUserInfo(userId).body()?.result?.toUserDetail()
-            ?: throw IllegalStateException("Response body is null")
+
+    override suspend fun getUserInfo(userId: Long): Result<UserDetail> = runCatching {
+        val response = userService.getUserInfo(userId)
+
+        when {
+            response.isSuccess() -> {
+                val userInfoDto = response.result ?: throw IllegalStateException("응답 성공 근데 값이 null")
+                userInfoDto.toUserDetail()
+            }
+
+            response.isClientError() -> throw ClientException(
+                response.message ?: "클라이언트 오류 발생"
+            )
+
+            response.isServerError() -> throw ServerException(
+                "서버 오류 발생 : ${response.status}"
+            )
+
+            else -> throw IllegalStateException(
+                "예기치 않은 status code: ${response.status}"
+            )
+        }
     }
 }

--- a/app/src/main/java/org/sopt/carrot/data/service/UserService.kt
+++ b/app/src/main/java/org/sopt/carrot/data/service/UserService.kt
@@ -7,8 +7,10 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface UserService {
+
     @GET("api/users/{userId}")
     suspend fun getUserInfo(
         @Path("userId") userId: Long
-    ): Response<BaseResponse<ResponseUserInfoDto>>
+    ): BaseResponse<ResponseUserInfoDto>
+
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/NavHost.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/NavHost.kt
@@ -51,8 +51,13 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
             )
         }
 
-        composable(ScreenRoutes.SELLER_PROFILE_SCREEN) {
-            SellerProfileScreen()
+        composable(
+            route = ScreenRoutes.SELLER_PROFILE_SCREEN_WITH_ARGS,
+            arguments = listOf(
+                navArgument("userId") { type = NavType.LongType }
+            )
+        ) {
+            SellerProfileScreen(navController)
         }
     }
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/ScreenRoute.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/ScreenRoute.kt
@@ -7,6 +7,7 @@ object ScreenRoutes {
     const val CATEGORY_SCREEN = "category_screen"
     const val MAIN_SCREEN = "main_screen"
     const val SELLER_PROFILE_SCREEN = "seller_profile_screen"
+    const val SELLER_PROFILE_SCREEN_WITH_ARGS = "$SELLER_PROFILE_SCREEN/{userId}"
     const val PRODUCT_DETAIL = "product_detail"
     const val PRODUCT_DETAIL_WITH_ARGS = "$PRODUCT_DETAIL/{productId}/{userId}"
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/productDetailScreen/ProductDetailScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/productDetailScreen/ProductDetailScreen.kt
@@ -115,6 +115,9 @@ fun ProductDetailScreen(
                     item {
                         UserInfoSection(
                             userInfo = productDetailInfo.userInfo,
+                            onProfileClick = { userId ->
+                                navController.navigate("${ScreenRoutes.SELLER_PROFILE_SCREEN}/$userId")
+                            },
                             modifier = Modifier.padding(horizontal = 16.dp)
                         )
                     }

--- a/app/src/main/java/org/sopt/carrot/presentation/productDetailScreen/components/UserInfoSection.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/productDetailScreen/components/UserInfoSection.kt
@@ -28,12 +28,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.sopt.carrot.R
+import org.sopt.carrot.core.extension.noRippleClickable
 import org.sopt.carrot.domain.model.UserDetail
 import org.sopt.carrot.ui.theme.CarrotTheme
 
 @Composable
 fun UserInfoSection(
     userInfo: UserDetail,
+    onProfileClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -43,19 +45,30 @@ fun UserInfoSection(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Row {
+        Row(
+            modifier = Modifier
+                .noRippleClickable { onProfileClick(userInfo.userId) }
+        ) {
             Box(
                 modifier = Modifier.size(48.dp),
                 contentAlignment = Alignment.BottomEnd
             ) {
-                AsyncImage(
-                    model = userInfo.profileImage ?: "",
-                    contentDescription = "프로필 이미지",
-                    modifier = Modifier
-                        .size(42.dp)
-                        .clip(CircleShape)
-                        .align(Alignment.TopStart)
-                )
+                if (userInfo.profileImage.isNullOrEmpty()) {
+                    Image(
+                        imageVector = ImageVector.vectorResource(R.drawable.img_user_sm),
+                        contentDescription = null
+                    )
+                } else {
+                    AsyncImage(
+                        model = userInfo.profileImage,
+                        contentDescription = "프로필 이미지",
+                        modifier = Modifier
+                            .size(42.dp)
+                            .clip(CircleShape)
+                            .align(Alignment.TopStart)
+                    )
+                }
+
                 Image(
                     imageVector = ImageVector.vectorResource(id = R.drawable.img_carrier_sm),
                     contentDescription = "캐리어 아이콘",
@@ -93,6 +106,7 @@ fun UserInfoSection(
                 )
             }
         }
+
         Column(
             modifier = Modifier.padding(vertical = 4.dp),
             horizontalAlignment = Alignment.End,
@@ -121,6 +135,7 @@ private fun UserInfoSectionPreview() {
             profileImage = "",
             address = "송파구 삼정동",
             userId = 1
-        )
+        ),
+        onProfileClick = {}
     )
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
@@ -35,7 +35,7 @@ import org.sopt.carrot.ui.theme.CarrotTheme
 @Composable
 fun SellerProfileScreen(
     navController: NavHostController,
-    viewmodel: SellerProfileViewmodel = viewModel(factory = ViewModelFactory())
+    viewmodel: SellerProfileViewModel = viewModel(factory = ViewModelFactory())
 ) {
 
     var isDialogVisible by remember { mutableStateOf(false) }

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,7 +49,7 @@ fun SellerProfileScreen(
         viewmodel.fetchSellerProfile(userId)
     }
 
-    val sellerProfile = viewmodel.sellerProfile
+    val sellerProfile by viewmodel.sellerProfile.collectAsState()
 
     Column(
         modifier = Modifier
@@ -72,10 +73,12 @@ fun SellerProfileScreen(
                 )
             }
 
-            SellerProfileContent(
-                onFollowClick = { isDialogVisible = true },
-                sellerProfile = sellerProfile
-            )
+            sellerProfile?.let { profile ->
+                SellerProfileContent(
+                    onFollowClick = { isDialogVisible = true },
+                    sellerProfile = profile
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,6 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import org.sopt.carrot.core.common.ViewModelFactory
+import org.sopt.carrot.domain.model.UserDetail
 import org.sopt.carrot.presentation.sellerProfile.component.SellerFollowDialog
 import org.sopt.carrot.presentation.sellerProfile.component.SellerProfileTopBar
 import org.sopt.carrot.presentation.sellerProfile.component.section.BadgeSection
@@ -26,9 +32,23 @@ import org.sopt.carrot.presentation.sellerProfile.component.section.SellerProfil
 import org.sopt.carrot.ui.theme.CarrotTheme
 
 @Composable
-fun SellerProfileScreen() {
+fun SellerProfileScreen(
+    navController: NavHostController,
+    viewmodel: SellerProfileViewmodel = viewModel(factory = ViewModelFactory())
+) {
 
     var isDialogVisible by remember { mutableStateOf(false) }
+
+    val userId = remember {
+        navController.currentBackStackEntry?.arguments?.getLong("userId")
+            ?: throw IllegalStateException("userId is required")
+    }
+
+    LaunchedEffect(userId) {
+        viewmodel.fetchSellerProfile(userId)
+    }
+
+    val sellerProfile = viewmodel.sellerProfile
 
     Column(
         modifier = Modifier
@@ -36,7 +56,7 @@ fun SellerProfileScreen() {
             .background(CarrotTheme.colors.white)
     ) {
         SellerProfileTopBar(
-            onBackClick = {},
+            onBackClick = { navController.popBackStack() },
             onShareClick = {},
             onMenuClick = {}
         )
@@ -53,7 +73,8 @@ fun SellerProfileScreen() {
             }
 
             SellerProfileContent(
-                onFollowClick = { isDialogVisible = true }
+                onFollowClick = { isDialogVisible = true },
+                sellerProfile = sellerProfile
             )
         }
     }
@@ -61,14 +82,16 @@ fun SellerProfileScreen() {
 
 @Composable
 private fun SellerProfileContent(
-    onFollowClick: () -> Unit
+    onFollowClick: () -> Unit,
+    sellerProfile: UserDetail
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize()
     ) {
         item {
             SellerProfileSection(
-                onFollowClick = onFollowClick
+                onFollowClick = onFollowClick,
+                sellerProfile = sellerProfile
             )
         }
         item { LocationSection() }
@@ -100,5 +123,8 @@ private fun SellerProfileContent(
 @Preview
 @Composable
 private fun PreviewSellerProfileScreen() {
-    SellerProfileScreen()
+    val mockNavController = rememberNavController()
+    SellerProfileScreen(
+        navController = mockNavController
+    )
 }

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
@@ -1,0 +1,45 @@
+package org.sopt.carrot.presentation.sellerProfile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.sopt.carrot.data.repositoryimpl.ClientException
+import org.sopt.carrot.data.repositoryimpl.ServerException
+import org.sopt.carrot.domain.model.UserDetail
+import org.sopt.carrot.domain.repository.UserRepository
+
+class SellerProfileViewmodel(
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    var sellerProfile by mutableStateOf(
+        UserDetail(
+            userId = -1L,
+            nickname = "",
+            profileImage = "",
+            address = ""
+        )
+    )
+        private set
+
+    fun fetchSellerProfile(userId: Long) {
+        viewModelScope.launch {
+            val result = userRepository.getUserInfo(userId)
+
+            result
+                .onSuccess { fetchedSellerProfile ->
+                    sellerProfile = fetchedSellerProfile
+                }
+                .onFailure { error ->
+                    val errorMessage = when (error) {
+                        is ClientException -> error.message
+                        is ServerException -> error.message
+                        else -> "알 수 없는 오류 발생."
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
@@ -11,7 +11,7 @@ import org.sopt.carrot.data.repositoryimpl.ServerException
 import org.sopt.carrot.domain.model.UserDetail
 import org.sopt.carrot.domain.repository.UserRepository
 
-class SellerProfileViewmodel(
+class SellerProfileViewModel(
     private val userRepository: UserRepository
 ) : ViewModel() {
 

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/SellerProfileViewmodel.kt
@@ -1,10 +1,10 @@
 package org.sopt.carrot.presentation.sellerProfile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.carrot.data.repositoryimpl.ClientException
 import org.sopt.carrot.data.repositoryimpl.ServerException
@@ -15,15 +15,8 @@ class SellerProfileViewmodel(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    var sellerProfile by mutableStateOf(
-        UserDetail(
-            userId = -1L,
-            nickname = "",
-            profileImage = "",
-            address = ""
-        )
-    )
-        private set
+    private val _sellerProfile = MutableStateFlow<UserDetail?>(null)
+    val sellerProfile: StateFlow<UserDetail?> = _sellerProfile.asStateFlow()
 
     fun fetchSellerProfile(userId: Long) {
         viewModelScope.launch {
@@ -31,7 +24,7 @@ class SellerProfileViewmodel(
 
             result
                 .onSuccess { fetchedSellerProfile ->
-                    sellerProfile = fetchedSellerProfile
+                    _sellerProfile.value = fetchedSellerProfile
                 }
                 .onFailure { error ->
                     val errorMessage = when (error) {

--- a/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/component/section/SellerProfileSection.kt
+++ b/app/src/main/java/org/sopt/carrot/presentation/sellerProfile/component/section/SellerProfileSection.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -22,7 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -31,18 +33,20 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import org.sopt.carrot.R
 import org.sopt.carrot.core.extension.noRippleClickable
+import org.sopt.carrot.domain.model.UserDetail
 import org.sopt.carrot.ui.theme.CarrotTheme
 
 @Composable
 fun SellerProfileSection(
-    onFollowClick: () -> Unit
+    onFollowClick: () -> Unit,
+    sellerProfile: UserDetail
 ) {
     Column(
         modifier = Modifier
@@ -55,10 +59,20 @@ fun SellerProfileSection(
             Box(
                 contentAlignment = Alignment.BottomEnd
             ) {
-                Image(
-                    imageVector = ImageVector.vectorResource(R.drawable.img_user_lg),
-                    contentDescription = null
-                )
+                if (sellerProfile.profileImage.isNullOrEmpty()) {
+                    Image(
+                        imageVector = ImageVector.vectorResource(R.drawable.img_user_lg),
+                        contentDescription = null
+                    )
+                } else {
+                    AsyncImage(
+                        model = sellerProfile.profileImage,
+                        contentDescription = "프로필 이미지",
+                        modifier = Modifier
+                            .size(62.dp)
+                            .clip(CircleShape)
+                    )
+                }
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.img_carrier_md),
                     contentDescription = null
@@ -73,7 +87,7 @@ fun SellerProfileSection(
                     horizontalArrangement = Arrangement.spacedBy(3.dp)
                 ) {
                     Text(
-                        text = "헿헿",
+                        text = sellerProfile.nickname,
                         color = CarrotTheme.colors.gray8,
                         style = CarrotTheme.typography.body.b_18
                     )
@@ -291,6 +305,12 @@ fun SellerProfileSection(
 @Composable
 private fun PreviewSellerProfileSection() {
     SellerProfileSection(
-        onFollowClick = {}
+        onFollowClick = {},
+        sellerProfile = UserDetail(
+            userId = 1L,
+            nickname = "asd",
+            profileImage = "",
+            address = ""
+        )
     )
 }

--- a/app/src/main/res/drawable/img_user_sm.xml
+++ b/app/src/main/res/drawable/img_user_sm.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="42dp"
+    android:height="42dp"
+    android:viewportWidth="42"
+    android:viewportHeight="42">
+    <path
+        android:strokeWidth="1"
+        android:pathData="M21,41.5C32.322,41.5 41.5,32.322 41.5,21C41.5,9.678 32.322,0.5 21,0.5C9.678,0.5 0.5,9.678 0.5,21C0.5,32.322 9.678,41.5 21,41.5Z"
+        android:fillColor="#ADB1BB"
+        android:strokeColor="#ADB1BB"/>
+    <path
+        android:pathData="M21,21m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+        android:fillColor="#E0E1E5"/>
+    <path
+        android:pathData="M8.212,36.609C10.339,32.12 15.041,29 20.5,29C26.185,29 31.049,32.384 33.039,37.174C29.69,39.576 25.52,41 21,41C16.136,41 11.679,39.351 8.212,36.609Z"
+        android:fillColor="#E0E1E5"
+        android:fillType="evenOdd"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M18.5,18.5L18.5,19.5"
+        android:fillColor="#00000000"
+        android:strokeColor="#ADB1BB"
+        android:strokeLineCap="round"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M24.5,18.5L24.5,19.5"
+        android:fillColor="#00000000"
+        android:strokeColor="#ADB1BB"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M18,23V23C19.335,26.052 23.665,26.052 25,23V23"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000"
+        android:strokeColor="#ADB1BB"
+        android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- [x] 리뷰는 (아직 미정)에 진행됩니다.
- [x] P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #27 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 프로필 정보 서버통신 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/0d051ade-dce7-4d19-beae-f53508346ef5


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 판매자 유저 정보 서버 연결 작업 구현했습니다!
- 이미지가 서버에서 null 값으로 와서 분기처리해서 디폴트 이미지로 적용했습니다!(값이 들어오면 서버에서 오는 이미지로 대체됨)
- 수정해야할 부분들이 좀 많이 보이는데,, 일관성있게 추후 방식 통일해서 적용해보도록 해봐요!!